### PR TITLE
Adding config for private npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://artifactory.smartertravel.net/artifactory/api/npm/npm-repo

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
-  "name": "@tappleby/react-typeahead-component",
+  "name": "st-react-typeahead-component",
   "description": "Typeahead, written using the React.js library.",
   "author": "Ezequiel Rodriguez <ezequiel@yahoo.com>",
-  "version": "0.10.0-alpha2",
+  "version": "1.0.0",
   "main": "./lib/index.js",
   "license": "MIT",
   "bugs": "https://github.com/ezequiel/react-typeahead-component/issues",
   "repository": {
     "type": "git",
     "url": "https://github.com/ezequiel/react-typeahead-component.git"
+  },
+  "publishConfig": {
+    "registry": "https://artifactory.smartertravel.net/artifactory/api/npm/npm-local"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
This is so when we run npm publish it will push `st-react-typeahead-component` to our instance of artifactory.
